### PR TITLE
cPickle now referred to as pickle in code

### DIFF
--- a/irlib/misc.py
+++ b/irlib/misc.py
@@ -247,7 +247,7 @@ def TryCache(fnm):
     if os.path.isfile(fnm):
         try:
             with open(fnm, 'r') as f:
-                unpickler = cPickle.Unpickler(f)
+                unpickler = pickle.Unpickler(f)
                 dataset = unpickler.load()
         except:
             traceback.print_exc()


### PR DESCRIPTION
Due to python 2/3 support cPickle module is imported as pickle but referred to as cPickle in code.

See the import section, row 11-14.
try:
import cPickle as pickle
except ImportError:
import pickle