### PR TITLE
Python 3 fix: automated picking

### DIFF
--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -1523,7 +1523,7 @@ class PickableGather(Gather):
         # Apply function over all traces
         try:
             picks = np.array(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T))
-            self.bed_picks[istart:iend] = picks + sbracket[0]
+            self.bed_picks[istart:iend] = list(picks) + sbracket[0]
             self.bed_phase[istart:iend] = 1
         except:
             traceback.print_exc()
@@ -1569,7 +1569,7 @@ class PickableGather(Gather):
         # Apply function over all traces
         try:
             picks = map(first_break_dc, self.data[sbracket[0]:sbracket[1],istart:iend].T)
-            self.dc_picks[istart:iend] = picks
+            self.dc_picks[istart:iend] = list(picks)
             self.dc_picks[istart:iend] += sbracket[0]
             self.dc_phase[istart:iend] = 1
         except:

--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -1522,8 +1522,8 @@ class PickableGather(Gather):
 
         # Apply function over all traces
         try:
-            picks = np.array(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T))
-            self.bed_picks[istart:iend] = list(picks) + sbracket[0]
+            picks = np.array(list(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T)))
+            self.bed_picks[istart:iend] = picks + sbracket[0]
             self.bed_phase[istart:iend] = 1
         except:
             traceback.print_exc()


### PR DESCRIPTION
The 'pick dc' and 'pick bed'-command (used in icepick2.py) now works with Python 3.

Picks are cast from a map-object to a list-object, needed by self.dc_picks[].