### PR TITLE
Python 3 fix: automated picking

### DIFF
--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -1523,7 +1523,7 @@ class PickableGather(Gather):
         # Apply function over all traces
         try:
             picks = np.array(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T))
-            self.bed_picks[istart:iend] = picks + sbracket[0]
+            self.bed_picks[istart:iend] = list(picks) + sbracket[0]
             self.bed_phase[istart:iend] = 1
         except:
             traceback.print_exc()
@@ -1569,7 +1569,7 @@ class PickableGather(Gather):
         # Apply function over all traces
         try:
             picks = map(first_break_dc, self.data[sbracket[0]:sbracket[1],istart:iend].T)
-            self.dc_picks[istart:iend] = picks
+            self.dc_picks[istart:iend] = list(picks)
             self.dc_picks[istart:iend] += sbracket[0]
             self.dc_phase[istart:iend] = 1
         except:

--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -836,7 +836,7 @@ class Gather(object):
         if fnm is None:
             fnm = self.GetCacheName()
         if os.path.isdir(os.path.split(fnm)[0]):
-            with open(fnm, 'w') as f:
+            with open(fnm, 'wb') as f:
                 pickler = pickle.Pickler(f, pickle.HIGHEST_PROTOCOL)
                 pickler.dump(self)
             return True

--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -1522,8 +1522,8 @@ class PickableGather(Gather):
 
         # Apply function over all traces
         try:
-            picks = np.array(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T))
-            self.bed_picks[istart:iend] = list(picks) + sbracket[0]
+            picks = np.array(list(map(first_break_bed, self.data[sbracket[0]:sbracket[1],istart:iend].T)))
+            self.bed_picks[istart:iend] = picks + sbracket[0]
             self.bed_phase[istart:iend] = 1
         except:
             traceback.print_exc()

--- a/irlib/misc.py
+++ b/irlib/misc.py
@@ -246,7 +246,7 @@ def TryCache(fnm):
     """
     if os.path.isfile(fnm):
         try:
-            with open(fnm, 'r') as f:
+            with open(fnm, 'rb') as f:
                 unpickler = pickle.Unpickler(f)
                 dataset = unpickler.load()
         except:


### PR DESCRIPTION
The automated picking in (used in icepick2.py) now works with Pyton 3.

Piacks are cast from a map-object to a list-object, needed by self.dc_picks[] and self.bed_picks[].