### PR TITLE
Fix errors in filters

### DIFF
--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -582,7 +582,7 @@ class Gather(object):
             M += 1
 
         X = np.arange(M+1) - M / 2
-        kernel = sig.blackman(M+1) * np.sinc(2*fc*X)
+        kernel = sig.windows.blackman(M+1) * np.sinc(2*fc*X)
         kernel /= np.sum(kernel)
         if mode == 'highpass':
             kernel = -kernel

--- a/irlib/gather.py
+++ b/irlib/gather.py
@@ -586,7 +586,7 @@ class Gather(object):
         kernel /= np.sum(kernel)
         if mode == 'highpass':
             kernel = -kernel
-            kernel[M/2] += 1.0
+            kernel[M // 2] += 1.0
 
         for i in range(self.data.shape[1]):
             self.data[:,i] = np.convolve(kernel, self.data[:,i], mode='same')

--- a/irlib/mig_fk.py
+++ b/irlib/mig_fk.py
@@ -305,10 +305,10 @@ def fkmig(D, dt, dx, v, params=None):
     D = np.vstack([D,np.zeros([ntpad,ntr])])
 
     # xpad
-    ntrnew = 2.0**nextpow2( round((xmax+xpad) / dx + 1) )
+    ntrnew = 2 ** nextpow2(round((xmax+xpad) / dx + 1))
     xmaxnew = (ntrnew-1)*dx + x[0]
     xnew = np.arange(x[0], xmaxnew+dx, dx)
-    nxpad = int(ntrnew-ntr)
+    nxpad = ntrnew-ntr
     D = np.hstack([D, np.zeros([nsampnew,nxpad])])
 
     # Forward f-k transform

--- a/irlib/mig_fk.py
+++ b/irlib/mig_fk.py
@@ -308,7 +308,7 @@ def fkmig(D, dt, dx, v, params=None):
     ntrnew = 2.0**nextpow2( round((xmax+xpad) / dx + 1) )
     xmaxnew = (ntrnew-1)*dx + x[0]
     xnew = np.arange(x[0], xmaxnew+dx, dx)
-    nxpad = ntrnew-ntr
+    nxpad = int(ntrnew-ntr)
     D = np.hstack([D, np.zeros([nsampnew,nxpad])])
 
     # Forward f-k transform


### PR DESCRIPTION
I encountered an issue with the lowpass filter in the following code:
```
  File "/irlib/irlib/gather.py", line 585, in DoWindowedSinc
    kernel = sig.blackman(M+1) * np.sinc(2*fc*X)
             ^^^^^^^^^^^^
AttributeError: module 'scipy.signal' has no attribute 'blackman'
```

I installed the environment using conda as per the documentation. My Python version is 3.12.4, and the scipy version is 1.14.0 (latest as of now).

A similar issue was found in a different repository:
https://github.com/fgnt/nara_wpe/issues/74

It was resolved by using `scipy.signal.windows.blackman` instead of `scipy.signal.blackman`.

**Update:**
I also fixed two additional errors in the filters:

**Error in highpass filter (fixed by performing floor division)**
```
  File "/irlib/irlib/gather.py", line 589, in DoWindowedSinc
    kernel[M/2] += 1.0
    ~~~~~~^^^^^
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

**Error in migfk filter (fixed by convertion from float to int)**
```
  File "/irlib/irlib/mig_fk.py", line 313, in fkmig
    D = np.hstack([D, np.zeros([nsampnew,nxpad])])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```





